### PR TITLE
Fix template text Wrench bytecode ownership

### DIFF
--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -2,10 +2,21 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
+#include <memory>
 #include <string>
 
 namespace esphome {
 namespace template_ {
+
+namespace {
+struct WrenchBytecodeDeleter {
+  void operator()(unsigned char *ptr) const {
+    if (ptr != nullptr) {
+      wr_free(ptr);
+    }
+  }
+};
+}  // namespace
 
 static const char *const TAG = "template.text";
 
@@ -82,20 +93,30 @@ void TemplateText::update() {
 }
 
 void TemplateText::execute_wrench(const std::string &value) {
-  int err = wr_compile(value.c_str(), strlen(value.c_str()), &this->outBytes, &this->outLen);  // compile it
+  unsigned char *bytecode_raw = nullptr;
+  int bytecode_len = 0;
+  int err = wr_compile(value.c_str(), value.size(), &bytecode_raw, &bytecode_len);  // compile it
 
   ESP_LOGD(TAG, "wrench err: %i", err);
-  if (err == 0) {
-    WRContext *gc = wr_run(this->w, this->outBytes, this->outLen);  // load and run the code!
-
-    WRValue *g = wr_getGlobalRef(gc, "result");
-
-    if (g) {
-      char buf[1024];
-      this->lambda_result_->publish_state(g->asString(buf, 1024));
+  if (err != 0) {
+    if (bytecode_raw != nullptr) {
+      wr_free(bytecode_raw);
     }
+    return;
+  }
 
-    delete[] outBytes;  // clean up
+  std::unique_ptr<unsigned char, WrenchBytecodeDeleter> bytecode(bytecode_raw);
+  WRContext *gc = wr_run(this->w, bytecode.get(), bytecode_len, false);  // load and run the code!
+
+  if (gc == nullptr) {
+    return;
+  }
+
+  WRValue *g = wr_getGlobalRef(gc, "result");
+
+  if (g != nullptr) {
+    char buf[1024];
+    this->lambda_result_->publish_state(g->asString(buf, 1024));
   }
 }
 


### PR DESCRIPTION
## Summary
- manage Wrench bytecode buffers with RAII to avoid double freeing and leak paths
- call `wr_run` without taking ownership so the local cleanup handles the compiled code consistently

## Testing
- ⚠️ `platformio run -d tests/test_build_components/build/.esphome/build/componenttestesp32ard` *(fails: environment lacks Arduino Wire headers for the vendored Wrench library)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c5373c68832588eb9a7e227fe625