### PR TITLE
Add QEMU workflow for OpenETH testing

### DIFF
--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -1,0 +1,52 @@
+---
+name: QEMU Tests
+
+on:
+  push:
+    branches: [dev, beta, release]
+    paths:
+      - 'esphome/components/ethernet/**'
+      - 'tests/qemu/**'
+      - 'tests/components/ethernet/**'
+      - 'script/run_qemu_tests.sh'
+      - '.github/workflows/qemu.yml'
+  pull_request:
+    paths:
+      - 'esphome/components/ethernet/**'
+      - 'tests/qemu/**'
+      - 'tests/components/ethernet/**'
+      - 'script/run_qemu_tests.sh'
+      - '.github/workflows/qemu.yml'
+  workflow_dispatch:
+
+jobs:
+  qemu:
+    name: Build and run in QEMU
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:release-v5.1
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.7
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          . "$IDF_PATH/export.sh"
+          python -m pip install --upgrade pip setuptools
+          pip install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
+          pip install -e .
+
+      - name: Run QEMU scenario
+        shell: bash
+        run: |
+          . "$IDF_PATH/export.sh"
+          ./script/run_qemu_tests.sh
+
+      - name: Upload QEMU logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qemu-logs
+          path: tests/qemu/.esphome/build/**/qemu.log
+          if-no-files-found: ignore

--- a/script/run_qemu_tests.sh
+++ b/script/run_qemu_tests.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+QEMU_TIMEOUT="${QEMU_TIMEOUT:-60}"
+
+if [[ -z "${IDF_PATH:-}" ]]; then
+  echo "IDF_PATH is not set. Please source the ESP-IDF environment." >&2
+  exit 1
+fi
+
+declare -a CONFIG_TARGETS=()
+
+if [[ "$#" -eq 0 ]]; then
+  while IFS= read -r config; do
+    CONFIG_TARGETS+=("$config")
+  done < <(find tests/qemu -maxdepth 1 -type f -name '*.yaml' | sort)
+else
+  CONFIG_TARGETS=("$@")
+fi
+
+if [[ "${#CONFIG_TARGETS[@]}" -eq 0 ]]; then
+  echo "No QEMU configuration files were found." >&2
+  exit 1
+fi
+
+for CONFIG_PATH in "${CONFIG_TARGETS[@]}"; do
+  if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "Configuration file $CONFIG_PATH not found." >&2
+    exit 1
+  fi
+
+  echo "=== Building QEMU scenario: $CONFIG_PATH ==="
+  CONFIG_DIR="$(dirname "$CONFIG_PATH")"
+  BUILD_ROOT="$CONFIG_DIR/.esphome"
+  PROJECT_ROOT="$BUILD_ROOT/build"
+  LOG_ROOT="$BUILD_ROOT/logs"
+
+  rm -rf "$BUILD_ROOT"
+
+  esphome compile --only-generate "$CONFIG_PATH"
+
+  if [[ ! -d "$PROJECT_ROOT" ]]; then
+    echo "Failed to locate generated project directory at $PROJECT_ROOT" >&2
+    exit 1
+  fi
+
+  PROJECT_DIR="$(find "$PROJECT_ROOT" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+  if [[ -z "$PROJECT_DIR" ]]; then
+    echo "Unable to determine IDF project directory inside $PROJECT_ROOT" >&2
+    exit 1
+  fi
+
+  mkdir -p "$LOG_ROOT"
+
+  pushd "$PROJECT_DIR" >/dev/null
+
+  idf.py build
+
+  RUN_LOG="$PROJECT_DIR/qemu.log"
+
+  set +e
+  timeout --signal=SIGINT --preserve-status "$QEMU_TIMEOUT" idf.py qemu | tee "$RUN_LOG"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  case "$status" in
+    0)
+      echo "QEMU exited normally." ;;
+    124)
+      echo "QEMU reached the ${QEMU_TIMEOUT}s timeout, treating as success." ;;
+    130)
+      echo "QEMU interrupted after ${QEMU_TIMEOUT}s timeout." ;;
+    *)
+      echo "QEMU failed with status $status" >&2
+      exit "$status"
+      ;;
+  esac
+
+  if ! grep -q "Starting scheduler" "$RUN_LOG"; then
+    echo "QEMU output did not contain expected scheduler startup message." >&2
+    exit 1
+  fi
+
+  SCENARIO_NAME="$(basename "$CONFIG_PATH" .yaml)"
+  cp "$RUN_LOG" "$LOG_ROOT/${SCENARIO_NAME}.log"
+
+  popd >/dev/null
+
+  echo "=== Completed QEMU scenario: $CONFIG_PATH ==="
+done

--- a/tests/qemu/.gitignore
+++ b/tests/qemu/.gitignore
@@ -1,0 +1,1 @@
+.esphome/

--- a/tests/qemu/openeth_qemu.yaml
+++ b/tests/qemu/openeth_qemu.yaml
@@ -1,0 +1,17 @@
+esphome:
+  name: qemu
+  friendly_name: qemu
+
+esp32:
+  board: esp32doit-devkit-v1
+  framework:
+    type: esp-idf
+
+logger:
+
+api:
+
+ethernet:
+  type: OPENETH
+
+web_server:


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to exercise OpenETH builds in QEMU
- provide a helper script that compiles, runs, and captures logs for QEMU scenarios
- add an OpenETH QEMU scenario configuration and ignore generated artifacts

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68da9e15eec08325a8fa528043aea44e